### PR TITLE
Added implementation of remote agents

### DIFF
--- a/setezor/database/queries_files/agent_queries.py
+++ b/setezor/database/queries_files/agent_queries.py
@@ -101,6 +101,12 @@ class AgentQueries(BaseQueries):
             return res
         else:
             raise IndexError(f"Can not update agent. No such agent with id {id}")
+        
+    @BaseQueries.session_provide
+    def get_ip_port(self, *, session: Session, agent_id: int) -> tuple[str, int]:
+        agent = self.get_by_id(session=session, id=agent_id)
+        ip = session.get(IP, agent.ip_id)
+        return ip.ip, 1337
 
     @BaseQueries.session_provide
     def delete_by_id(self, session: Session, id: int, default_agent: int = None):

--- a/setezor/setezor.py
+++ b/setezor/setezor.py
@@ -29,6 +29,7 @@ from setezor.modules.application import PMApplication, PMRequest
 from setezor.app_routes.middlewares import setup_middlewares
 from setezor.exceptions.loggers import get_logger, LoggerNames
 from setezor.before_run import check_software
+from setezor.spy import spy as spy_instanse
 
 nest_asyncio.apply()
 init()
@@ -79,11 +80,15 @@ def create_ssl_context():
 
 @click.command()
 @click.option('-p', '--port', default=16661, type=int, show_default=True, help='Number of port to binding')
-def run_app(port: int):
-    web.run_app(app=create_app(port=port), host=HOST, port=port, 
-                access_log=get_logger(LoggerNames.web_server, handlers=['file']), 
-                print=print_banner(HOST, port),
-                ssl_context=create_ssl_context())
+@click.option('-s', '--spy', default=False, type=bool, show_default=True, help='Enable spy', is_flag=True)
+def run_app(port: int, spy: bool):
+    if spy:
+        spy_instanse.serve(host=HOST, port=port)
+    else:
+        web.run_app(app=create_app(port=port), host=HOST, port=port, 
+                    access_log=get_logger(LoggerNames.web_server, handlers=['file']), 
+                    print=print_banner(HOST, port),
+                    ssl_context=create_ssl_context())
 
 
 

--- a/setezor/spy.py
+++ b/setezor/spy.py
@@ -1,0 +1,96 @@
+from typing import TypeVar, Generic, Callable, Any, ParamSpec
+import inspect
+
+from aiohttp import web
+import aiohttp
+from pydantic import TypeAdapter
+import orjson
+
+from setezor.tools.ip_tools import get_default_interface, get_ipv4
+
+
+MACHINE_IP = get_ipv4(get_default_interface())
+_P = ParamSpec("_P")
+_Returns = TypeVar("_Returns")
+
+
+class SpyMethod(Generic[_P, _Returns]):
+    def __init__(self, func: Callable[_P, _Returns]) -> None:
+        self._func = func
+        self.__kwargs_adapters = {k: TypeAdapter(v) for k, v in self._func.__annotations__.items() if k != 'return'}
+        self.__return_adapter = TypeAdapter(func.__annotations__['return'])
+
+    def __call__(self, *args: _P.args, **kwargs: _P.kwargs) -> _Returns:
+        return self._func(*args, **kwargs)
+    
+    async def run_on_agent(self, agent_ip: str, agent_port: int, *args: _P.args, **kwargs: _P.kwargs) -> _Returns:
+        if agent_ip != MACHINE_IP: # для теста на локальной машине поменять, тогда все вызовы будут идти через спай
+            url = self._format_url(agent_ip, agent_port)
+            kwargs = self.__format_args_to_kwargs(self._func, *args, **kwargs)
+            for var_name, adapter in self.__kwargs_adapters.items():
+                if var_name in kwargs:
+                    kwargs[var_name] = adapter.dump_python(kwargs[var_name])
+            return await self.__make_request(url, **kwargs)
+        else:
+            return await self._func(*args, **kwargs)
+
+    @property
+    def server_path(self) -> str:
+        return '/' + self._func.__qualname__.replace('.', '/')
+    
+    def _format_url(self, agent_ip: str, agent_port: int) -> str:
+        return f'http://{agent_ip}:{agent_port}{self.server_path}'
+
+    def __format_args_to_kwargs(self, func: Callable, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        """
+        Converts positional and keyword arguments into a dictionary of keyword arguments,
+        including default values for those not provided explicitly.
+        """
+        signature = inspect.signature(func)
+        bound_args = signature.bind(*args, **kwargs)
+        formatted_kwargs = {name: value for name, value in bound_args.arguments.items()}
+
+        for param in signature.parameters.values():
+            if param.name not in formatted_kwargs:
+                if param.default is not inspect.Parameter.empty:
+                    formatted_kwargs[param.name] = param.default
+
+        return formatted_kwargs
+    
+    async def __make_request(self, url: str, **kwargs: Any) -> _Returns:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(url, data=orjson.dumps(kwargs)) as response:
+                return self.__return_adapter.validate_json(await response.read())
+            
+    def __server_function__(self) -> Callable[[web.Request], web.Response]:
+        async def handler(request: web.Request) -> web.Response:
+            data = await request.read()
+            kwargs = orjson.loads(data)
+            for var_name, adapter in self.__kwargs_adapters.items():
+                if var_name in kwargs:
+                    kwargs[var_name] = adapter.validate_python(kwargs[var_name])
+            result = await self(**kwargs)
+            return_data = self.__return_adapter.dump_json(result)
+            return web.Response(body=return_data, content_type='application/json')
+        return handler
+            
+
+class Spy:
+    _methods: list[SpyMethod] = []
+    
+    @classmethod
+    def spy_method(cls, func: Callable[_P, _Returns]) -> SpyMethod[_P, _Returns]:
+        method = SpyMethod(func)
+        cls._methods.append(method)
+        return method
+    
+    def serve(self, host: str, port: int) -> None:
+        app = web.Application()
+        routes = []
+        for method in self._methods:
+            routes.append(web.route('POST', method.server_path, method.__server_function__()))
+        app.add_routes(routes)
+        web.run_app(app, host=host, port=port)
+        
+
+spy = Spy()

--- a/setezor/spy.py
+++ b/setezor/spy.py
@@ -13,7 +13,7 @@ MACHINE_IP = get_ipv4(get_default_interface())
 _P = ParamSpec("_P")
 _Returns = TypeVar("_Returns")
 
-
+import types
 class SpyMethod(Generic[_P, _Returns]):
     def __init__(self, func: Callable[_P, _Returns]) -> None:
         self._func = func
@@ -69,6 +69,10 @@ class SpyMethod(Generic[_P, _Returns]):
             for var_name, adapter in self.__kwargs_adapters.items():
                 if var_name in kwargs:
                     kwargs[var_name] = adapter.validate_python(kwargs[var_name])
+                    
+            # todo поменять, у сущности агента должны быть интерфейсы
+            if 'iface' in kwargs:
+                kwargs['iface'] = get_default_interface()
             result = await self(**kwargs)
             return_data = self.__return_adapter.dump_json(result)
             return web.Response(body=return_data, content_type='application/json')


### PR DESCRIPTION
Дабавил имплементацию удаленных агентов, как и хотели изначально, для запуска агента, нужно запустить сетезор с флагом --spy. Оттестировано на нмап. Для полной имплементации у сущности агента должен быть порт, а так же его список интерфейсов (сейчас показываются интерфейсы текущей машины, а должны агента). В этой имплементации агенты используют свой дефолтный интерфейс. Для добавления новой функции агента, нужно всего лишь повесить декоратор на метод (метод должен быть обязательно статический)